### PR TITLE
WI 3560347: Improve Client decision documentation in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,32 +117,6 @@ The official Cds samples are divided in multiple categories depending on the sce
     </td>
     <td align="middle" valign="top">
       <b>
-        <a href="https://github.com/osisoft/sample-adh-authentication_hybrid-dotnet"> Hybrid Flow</a>
-      </b>
-      <br />
-      Click for
-      <a href="docs/AUTHENTICATION.md"> details </a>
-      on this type of authentication
-      <br />
-      <br />
-      <table align="middle">
-        <tr>
-          <td align="middle">
-            <a href="https://github.com/osisoft/sample-adh-authentication_hybrid-dotnet">.NET</a>
-          </td>
-          <td align="middle">
-              <img
-                src="https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-authentication_hybrid-dotnet?branchName=main"
-                alt="Build Status"
-              />
-          </td>
-        </tr>
-      </table>
-    </td>
-  </tr>
-  <tr>
-    <td align="middle" valign="top">
-      <b>
         <a href="docs/AUTHENTICATION.md"> Authorization Code + PKCE </a>
       </b>
       <br />
@@ -187,7 +161,6 @@ The official Cds samples are divided in multiple categories depending on the sce
         </tr>
       </table>
     </td>
-    <td></td>
   </tr>
 </table>
 </details>
@@ -907,7 +880,7 @@ The official Cds samples are divided in multiple categories depending on the sce
 </details>
 <br>
 
-**Note**: Tests with automated UI browser components (such as Hybrid Authentication, Authorization Code Flow and Angular samples) fail intermittently due to automation issues.
+**Note**: Tests with automated UI browser components (Authorization Code Flow and Angular samples) fail intermittently due to automation issues.
 
 For OMF to Cds samples please see the OMF repository: [Aveva-Samples-OMF](https://github.com/osisoft/OSI-Samples-OMF)
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -37,26 +37,13 @@ These are some of the terms that you will encounter in this document and other r
 
 ## Cds Supported Authenticated Flows
 
-Currently Cds supports a number of authentication flows. Based on your requirements choose the one that best fits your needs. The following subsections are more technical and implementation oriented than the first part of the document.
-
-### Authorization Code Flow with PKCE
-
-If you are developing any Javascript/Browser (SPA) based applications or native mobile applications, with the user (resource owner) trying to access resources, use this flow. This flow adds an extra layer of security on top of the OIDC implicit flow by:
-
-1. Requiring a client-verified code exchange for access token
-2. By not returning the access token in a redirect URI.
-
-In this OIDC flow, no refresh token is provided.
-
-Authorization Code Flow supports silent refresh, which makes it possible to receive a new access token while the user is both using the application and logged in with the Identity Provider in the same browser session. This is done behind the scenes without interrupting the user experience.
-
-The sample for this authentication flow can be found [here for DotNet](https://github.com/osisoft/sample-adh-authentication_authorization-dotnet), [here for NodeJS](https://github.com/osisoft/sample-adh-authentication_authorization-nodejs), and [here for Python](https://github.com/osisoft/sample-adh-authentication_authorization-python).
+Currently Cds supports two authentication flows. Based on your requirements choose the one that best fits your needs. The following subsections are more technical and implementation oriented than the first part of the document.
 
 ### Client Credential Flow
 
-If you are writing software (client) to communicate with Cds without the presence of a user, then this is authentication flow you should follow. This flow was created for machine to machine communication.
+If you are writing software (client) to communicate with Cds without the presence of a user (resource owner), then this is the authentication flow you should follow. This flow was created for machine to machine communication.
 
-A client is any software that a resource owner uses to access his resources on a remote server. In this case the client itself is the resource owner, and there is no actual user to perform the authentication process. The client uses his Client Id and Client Secret to authenticate against Cds and is awarded an Access Token. It is assumed that the client stores the Client Secret in a safe location, and uses cryptographically secure channels -read https- to communicate with Cds. Cds only supports communication over https. No Refresh Token is awarded.
+The client uses its Client Id and Client Secret to authenticate against Cds and is awarded an Access Token. It is assumed that the client stores the Client Secret in a safe location, and uses cryptographically secure channels -read https- to communicate with Cds. Cds only supports communication over https. No Refresh Token is awarded.
 
 The overall steps for this process are as follows:
 1. Obtain the needed configuration information, including Tenant ID, Client ID, and Client Secret
@@ -64,19 +51,29 @@ The overall steps for this process are as follows:
 1. POST the Client ID and Secret to the token endpoint in order to get an access (bearer) token 
 1. Pass it back to ADH in the Authorization header in subsequent calls (the base tenant endpoint is used in these samples)
 
+![image](https://github.com/user-attachments/assets/81dd8676-4fce-4b12-8a13-bc97e1dafbdb)
+
 The samples for this authentication flow are found in the `Client Credential Flow` section of the table below.
 
-### Hybrid Flow
+### Authorization Code Flow with PKCE
 
-If you are developing a traditional thick applications, with the user trying to access resources this should be your authentication method of choice. This flow provides a more secure means of authenticating, but also has the most constraining requirements. In this case the user will authenticate against the identity provider using any type of browser, even an unsafe one. Once this is completed the server-side client will authenticate against the authorization server and be awarded an Access Token and a Refresh Token, which should never be displayed to the user or the browser.
+If you are developing any application where a user (resource owner) needs to access resources, use this flow. This flow adds an extra layer of security on top of the OIDC implicit flow by:
 
-The sample for this authentication flow can be found [here](https://github.com/osisoft/sample-adh-authentication_hybrid-dotnet).
+1. Requiring a client-verified code exchange for access token
+2. By not returning the access token in a redirect URI.
+
+The client app uses its Client Id and Client Secret to request an authorization code from the authorization server. The user is then directed to authenticate themselves with the authorization server (login prompt, 2 factor authentication, etc.) If the user successfully authenticates, an authorization code is returned to the client app, and the client can request Access Tokens with this authorization code. The client can then pass this Access Token in the authorization header in requests to get data from Cds.
+
+![image](https://github.com/user-attachments/assets/f22457fb-0d46-4ff7-8af2-31acbb145464)
+
+In this flow, no refresh token is provided. Authorization Code Flow supports silent refresh, which makes it possible to receive a new access token while the user is both using the application and logged in with the Identity Provider in the same browser session. This is done behind the scenes without interrupting the user experience. 
+
+The sample for this authentication flow can be found [here for DotNet](https://github.com/osisoft/sample-adh-authentication_authorization-dotnet), [here for NodeJS](https://github.com/osisoft/sample-adh-authentication_authorization-nodejs), and [here for Python](https://github.com/osisoft/sample-adh-authentication_authorization-python).
 
 | Tasks  | Languages  | 
 | ---- | --- |
 | **Authorization Code Flow** | [.NET](https://github.com/osisoft/sample-adh-authentication_authorization-dotnet) </br> [NodeJS](https://github.com/osisoft/sample-adh-authentication_authorization-nodejs) </br> [Python](https://github.com/osisoft/sample-adh-authentication_authorization-python) | 
 | **Client Credential Flow**  | [.NET Libraries](https://github.com/osisoft/sample-adh-authentication_client_credentials-dotnet) </br> [.NET REST API](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-dotnet) </br> [Java](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-java) </br> [NodeJS](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-nodejs) </br> [Postman](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-postman)</br> [Powershell](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-powershell) </br> [Python](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-python) </br> [Rust](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-rust) |
-| **Hybrid Flow**             | [.NET](https://github.com/osisoft/sample-adh-authentication_hybrid-dotnet)  |
 
 For the main ADH page [ReadMe](https://github.com/osisoft/OSI-Samples-adh)  
 For the main samples page [ReadMe](https://github.com/osisoft/OSI-Samples)

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -43,7 +43,7 @@ Currently CDS supports two authentication flows. Based on your requirements choo
 
 If you are writing software (client) to communicate with CDS without the presence of a user (resource owner), then this is the authentication flow you should follow. This flow was created for machine to machine communication.
 
-The client uses its Client Id and Client Secret to authenticate against CDS and is awarded an Access Token. It is assumed that the client stores the Client Secret in a safe location, and uses cryptographically secure channels -read https- to communicate with CDS. CDS only supports communication over https. No Refresh Token is awarded.
+The client uses its client id and client secret to authenticate against CDS and is awarded an access token. It is assumed that the client stores the client secret in a safe location, and uses cryptographically secure channels -read https- to communicate with CDS. CDS only supports communication over https. No refresh token is awarded.
 
 The overall steps for this process are as follows:
 1. Obtain the needed configuration information, including Tenant ID, Client ID, and Client Secret
@@ -62,11 +62,11 @@ If you are developing any application where a user (resource owner) needs to acc
 1. Requiring a client-verified code exchange for access token
 2. By not returning the access token in a redirect URI.
 
-The client app uses its Client Id and Client Secret to request an authorization code from the authorization server. The user is then directed to authenticate themselves with the authorization server (login prompt, 2 factor authentication, etc.) If the user successfully authenticates, an authorization code is returned to the client app, and the client can request Access Tokens with this authorization code. The client can then pass this Access Token in the authorization header in requests to get data from CDS.
+The client app uses its client id and client secret to request an authorization code from the authorization server. The user is then directed to authenticate themselves with the authorization server (login prompt, 2 factor authentication, etc.) If the user successfully authenticates, an authorization code is returned to the client app, and the client can request Access Tokens with this authorization code. The client can then pass this access token in the authorization header in requests to get data from CDS.
 
 ![image](https://github.com/user-attachments/assets/f22457fb-0d46-4ff7-8af2-31acbb145464)
 
-In this flow, no refresh token is provided. Authorization Code Flow supports silent refresh, which makes it possible to receive a new access token while the user is both using the application and logged in with the Identity Provider in the same browser session. This is done behind the scenes without interrupting the user experience. 
+In this flow, no refresh token is provided. Authorization Code Flow supports silent refresh, which makes it possible to receive a new access token while the user is both using the application and logged in with the identity provider in the same browser session. This is done behind the scenes without interrupting the user experience. 
 
 The sample for this authentication flow can be found [here for DotNet](https://github.com/osisoft/sample-adh-authentication_authorization-dotnet), [here for NodeJS](https://github.com/osisoft/sample-adh-authentication_authorization-nodejs), and [here for Python](https://github.com/osisoft/sample-adh-authentication_authorization-python).
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,6 +1,6 @@
 # Intro
 
-This document is a guide on how to connect to CONNECT data services (Cds) using a client of your choice. We will first cover the difference between authorization (AuthZ) and authentication (AuthN) and how they relate to you as a developer of ADH. Then we will introduce some possible scenarios using some GitHub examples.
+This document is a guide on how to connect to CONNECT data services (CDS) using a client of your choice. We will first cover the difference between authorization (AuthZ) and authentication (AuthN) and how they relate to you as a developer of CDS. Then we will introduce some possible scenarios using some GitHub examples.
 
 ## Authentication
 
@@ -12,9 +12,9 @@ Authorization is related to, but not the same as authentication. Authorization i
 
 If you are taking a flight, at the gate you show your ticket to prove that you are authorized to access the flight. You also show a form of identification to show that you are the person whose name is listed on that ticket; in other words, you authenticate yourself.
 
-## ADH Authentication and Authorization
+## CDS Authentication and Authorization
 
-ADH uses implementations of [OpenID Connect](https://openid.net/connect/) connect and [OAuth 2.0](https://oauth.net/2/) to handle authentication and authorization. Our implementation of these protocols relies on third party _Identity Providers_ (e.g., Microsoft Accounts, Azure Active Directory, etc.), and does not allow user accounts to be created or stored in ADH.
+CDS uses implementations of [OpenID Connect](https://openid.net/connect/) connect and [OAuth 2.0](https://oauth.net/2/) to handle authentication and authorization. Our implementation of these protocols relies on third party _Identity Providers_ (e.g., Microsoft Accounts, Azure Active Directory, etc.), and does not allow user accounts to be created or stored in CDS.
 
 ## All the Parties involved
 
@@ -22,8 +22,8 @@ For the rest of this document we will use the following language to refer to the
 
 - Resource Owner - This is a typically a user who owns some sort of resource in a server. For example, a company employee who has been registered as part of a tenant.
 - Client - Any software that the _resource owner_ uses to access resources. For example, a console app used to access data, a web browser, or a native application.
-- Resource Server - The server that holds some resources, owned by users, which they try to access. For example, the Cds Service that hold data for a tenant.
-- Authorization Server - The server that generates an Access Token for a client once it has been authenticated and given the right permissions by the resource owner. In our case this would be the Cds Identity Service.
+- Resource Server - The server that holds some resources, owned by users, which they try to access. For example, the CDS Service that hold data for a tenant.
+- Authorization Server - The server that generates an Access Token for a client once it has been authenticated and given the right permissions by the resource owner. In our case this would be the CDS Identity Service.
 - IdentityProvider - a third party that creates, maintains, and manages identity information for principals while providing authentication services. For example, Microsoft Account and Azure Active Directory.
 
 ## Other terms
@@ -35,21 +35,21 @@ These are some of the terms that you will encounter in this document and other r
 - Access Token - The JWT that results from a successful authentication process, and contains some predefined fields. This is sent as part of the Authorization header with all the following requests in the session.
 - Refresh Token - A token used to get a new Access Token after the current one expires, without having to go through the authentication process again. Usually has a long expiration date.
 
-## Cds Supported Authenticated Flows
+## CDS Supported Authenticated Flows
 
-Currently Cds supports two authentication flows. Based on your requirements choose the one that best fits your needs. The following subsections are more technical and implementation oriented than the first part of the document.
+Currently CDS supports two authentication flows. Based on your requirements choose the one that best fits your needs. The following subsections are more technical and implementation oriented than the first part of the document.
 
 ### Client Credential Flow
 
-If you are writing software (client) to communicate with Cds without the presence of a user (resource owner), then this is the authentication flow you should follow. This flow was created for machine to machine communication.
+If you are writing software (client) to communicate with CDS without the presence of a user (resource owner), then this is the authentication flow you should follow. This flow was created for machine to machine communication.
 
-The client uses its Client Id and Client Secret to authenticate against Cds and is awarded an Access Token. It is assumed that the client stores the Client Secret in a safe location, and uses cryptographically secure channels -read https- to communicate with Cds. Cds only supports communication over https. No Refresh Token is awarded.
+The client uses its Client Id and Client Secret to authenticate against CDS and is awarded an Access Token. It is assumed that the client stores the Client Secret in a safe location, and uses cryptographically secure channels -read https- to communicate with CDS. CDS only supports communication over https. No Refresh Token is awarded.
 
 The overall steps for this process are as follows:
 1. Obtain the needed configuration information, including Tenant ID, Client ID, and Client Secret
-1. Check the token (authentication) endpoint from the ADH discovery URL
+1. Check the token (authentication) endpoint from the CDS discovery URL
 1. POST the Client ID and Secret to the token endpoint in order to get an access (bearer) token 
-1. Pass it back to ADH in the Authorization header in subsequent calls (the base tenant endpoint is used in these samples)
+1. Pass it back to CDS in the Authorization header in subsequent calls (the base tenant endpoint is used in these samples)
 
 ![image](https://github.com/user-attachments/assets/81dd8676-4fce-4b12-8a13-bc97e1dafbdb)
 
@@ -62,7 +62,7 @@ If you are developing any application where a user (resource owner) needs to acc
 1. Requiring a client-verified code exchange for access token
 2. By not returning the access token in a redirect URI.
 
-The client app uses its Client Id and Client Secret to request an authorization code from the authorization server. The user is then directed to authenticate themselves with the authorization server (login prompt, 2 factor authentication, etc.) If the user successfully authenticates, an authorization code is returned to the client app, and the client can request Access Tokens with this authorization code. The client can then pass this Access Token in the authorization header in requests to get data from Cds.
+The client app uses its Client Id and Client Secret to request an authorization code from the authorization server. The user is then directed to authenticate themselves with the authorization server (login prompt, 2 factor authentication, etc.) If the user successfully authenticates, an authorization code is returned to the client app, and the client can request Access Tokens with this authorization code. The client can then pass this Access Token in the authorization header in requests to get data from CDS.
 
 ![image](https://github.com/user-attachments/assets/f22457fb-0d46-4ff7-8af2-31acbb145464)
 
@@ -75,5 +75,5 @@ The sample for this authentication flow can be found [here for DotNet](https://g
 | **Authorization Code Flow** | [.NET](https://github.com/osisoft/sample-adh-authentication_authorization-dotnet) </br> [NodeJS](https://github.com/osisoft/sample-adh-authentication_authorization-nodejs) </br> [Python](https://github.com/osisoft/sample-adh-authentication_authorization-python) | 
 | **Client Credential Flow**  | [.NET Libraries](https://github.com/osisoft/sample-adh-authentication_client_credentials-dotnet) </br> [.NET REST API](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-dotnet) </br> [Java](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-java) </br> [NodeJS](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-nodejs) </br> [Postman](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-postman)</br> [Powershell](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-powershell) </br> [Python](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-python) </br> [Rust](https://github.com/osisoft/sample-adh-authentication_client_credentials_simple-rust) |
 
-For the main ADH page [ReadMe](https://github.com/osisoft/OSI-Samples-adh)  
+For the main CDS page [ReadMe](https://github.com/osisoft/OSI-Samples-adh)  
 For the main samples page [ReadMe](https://github.com/osisoft/OSI-Samples)

--- a/portal/hybrid_samples.json
+++ b/portal/hybrid_samples.json
@@ -1,7 +1,0 @@
-[
-    {
-      "Title": ".NET",
-      "Description": "Authenticating to CONNECT data services using Hybrid Flow in .NET",
-      "Url": "https://github.com/osisoft/sample-adh-authentication_hybrid-dotnet"
-    }
-]


### PR DESCRIPTION
In the documentation for authentication mode samples, we describe Hybrid mode authentication which is no longer applicable for CONNECT Data Services, so that was removed. We also needed some improvement to the explanations we have for why users should choose certain authentication methods. 

For example, instead of telling users to use Authorization code flow "...if you are developing any Javascript/Browser (SPA) based applications or native mobile applications" we can say they should "...if you are developing any application where a user (resource owner) needs to access resources" 